### PR TITLE
added relaxed attention to encoder-decoder attention (arxiv.org/abs/2107.01275)

### DIFF
--- a/espresso/models/transformer/speech_transformer_config.py
+++ b/espresso/models/transformer/speech_transformer_config.py
@@ -74,6 +74,13 @@ class SpeechDecoderConfig(SpeechEncDecBaseConfig):
             "help": "decoder output dimension (extra linear layer if different from decoder embed dim)"
         },
     )
+    relaxed_attention: float = field(
+        default=0.0,
+        metadata={
+            "help": "relaxed attention weight appplied to source attention",
+            "alias": "--relaxed-attention",
+        },
+    )   
 
     def __post_init__(self):
         #  II doesn't work if we are just creating the object outside of hydra so fix that

--- a/espresso/models/transformer/speech_transformer_config.py
+++ b/espresso/models/transformer/speech_transformer_config.py
@@ -74,11 +74,11 @@ class SpeechDecoderConfig(SpeechEncDecBaseConfig):
             "help": "decoder output dimension (extra linear layer if different from decoder embed dim)"
         },
     )
-    relaxed_attention: float = field(
+    relaxed_attention_weight: float = field(
         default=0.0,
         metadata={
             "help": "relaxed attention weight appplied to source attention",
-            "alias": "--relaxed-attention",
+            "alias": "--decoder-relaxed-attention-weight",
         },
     )   
 

--- a/espresso/modules/transformer_with_relative_positional_embedding_layer.py
+++ b/espresso/modules/transformer_with_relative_positional_embedding_layer.py
@@ -95,6 +95,18 @@ class TransformerWithRelativePositionalEmbeddingDecoderLayerBase(
             max_relative_pos=max_relative_pos,
         )
 
+    def build_encoder_attention(self, embed_dim, cfg):
+        return MultiheadAttention(
+            embed_dim,
+            cfg.decoder.attention_heads,
+            kdim=cfg.encoder.embed_dim,
+            vdim=cfg.encoder.embed_dim,
+            dropout=cfg.attention_dropout,
+            encoder_decoder_attention=True,
+            relaxed_attention_weight=cfg.decoder.relaxed_attention_weight,
+            q_noise=self.quant_noise,
+            qn_block_size=self.quant_noise_block_size,
+        )
 
 # backward compatible with the legacy argparse format
 class TransformerWithRelativePositionalEmbeddingDecoderLayer(

--- a/examples/asr_wsj/run.sh
+++ b/examples/asr_wsj/run.sh
@@ -282,7 +282,7 @@ if [ ${stage} -le 9 ]; then
   [ -f $dir/checkpoint_last.pt ] && log_file="-a $log_file"
   update_freq=$(((2+ngpus-1)/ngpus))
   if $use_transformer; then
-    opts="$opts --arch speech_transformer_wsj --max-epoch 100 --lr-scheduler tri_stage"
+    opts="$opts --arch speech_transformer_wsj --max-epoch 100 --decoder-relaxed-attention 0.35 --lr-scheduler tri_stage"
     opts="$opts --warmup-steps $((25000/ngpus/update_freq)) --hold-steps $((60000/ngpus/update_freq)) --decay-steps $((100000/ngpus/update_freq))"
   else
     opts="$opts --arch speech_conv_lstm_wsj --max-epoch 35 --lr-scheduler reduce_lr_on_plateau_v2"
@@ -297,7 +297,7 @@ if [ ${stage} -le 9 ]; then
     --optimizer adam --lr 0.001 --weight-decay 0.0 \
     --save-dir $dir --restore-file checkpoint_last.pt --save-interval-updates $((800/ngpus/update_freq)) \
     --keep-interval-updates 5 --keep-last-epochs 5 --validate-interval 1 --best-checkpoint-metric wer \
-    --criterion label_smoothed_cross_entropy_v2 --relaxed-attention 0.35 --label-smoothing 0.05 --smoothing-type temporal \
+    --criterion label_smoothed_cross_entropy_v2 --label-smoothing 0.05 --smoothing-type temporal \
     --dict $dict --bpe characters_asr --non-lang-syms $nlsyms \
     --max-source-positions 3000 --max-target-positions 300 $opts 2>&1 | tee $log_file
 fi

--- a/examples/asr_wsj/run.sh
+++ b/examples/asr_wsj/run.sh
@@ -297,7 +297,7 @@ if [ ${stage} -le 9 ]; then
     --optimizer adam --lr 0.001 --weight-decay 0.0 \
     --save-dir $dir --restore-file checkpoint_last.pt --save-interval-updates $((800/ngpus/update_freq)) \
     --keep-interval-updates 5 --keep-last-epochs 5 --validate-interval 1 --best-checkpoint-metric wer \
-    --criterion label_smoothed_cross_entropy_v2 --label-smoothing 0.05 --smoothing-type temporal \
+    --criterion label_smoothed_cross_entropy_v2 --relaxed-attention 0.35 --label-smoothing 0.05 --smoothing-type temporal \
     --dict $dict --bpe characters_asr --non-lang-syms $nlsyms \
     --max-source-positions 3000 --max-target-positions 300 $opts 2>&1 | tee $log_file
 fi

--- a/fairseq/modules/multihead_attention.py
+++ b/fairseq/modules/multihead_attention.py
@@ -139,7 +139,6 @@ class MultiheadAttention(nn.Module):
         attn_mask: Optional[Tensor] = None,
         before_softmax: bool = False,
         need_head_weights: bool = False,
-        encoder_attn_relaxation: float = None,                           
     ) -> Tuple[Tensor, Optional[Tensor]]:
         """Input shape: Time x Batch x Channel
 
@@ -409,11 +408,9 @@ class MultiheadAttention(nn.Module):
         )
         attn_weights = attn_weights_float.type_as(attn_weights)
 
-        if self.training and self.relaxed_attention_weight is not None:
-            attn_weights = attn_weights \
-                .mul(1 - self.relaxed_attention_weight) \
-                .add(self.relaxed_attention_weight * (1 / src_len))
-                
+        if self.training and self.relaxed_attention_weight > 0.0:
+            attn_weights = (1.0 - self.relaxed_attention_weight) * attn_weights + self.relaxed_attention_weight / src_len
+
         attn_probs = self.dropout_module(attn_weights)
 
         assert v is not None

--- a/fairseq/modules/transformer_layer.py
+++ b/fairseq/modules/transformer_layer.py
@@ -307,6 +307,7 @@ class TransformerDecoderLayerBase(nn.Module):
             vdim=cfg.encoder.embed_dim,
             dropout=cfg.attention_dropout,
             encoder_decoder_attention=True,
+            relaxed_attention_weight=cfg.decoder.relaxed_attention,                     
             q_noise=self.quant_noise,
             qn_block_size=self.quant_noise_block_size,
         )
@@ -329,6 +330,7 @@ class TransformerDecoderLayerBase(nn.Module):
         self_attn_padding_mask: Optional[torch.Tensor] = None,
         need_attn: bool = False,
         need_head_weights: bool = False,
+        encoder_attn_relaxation: float = None,                           
     ):
         """
         Args:
@@ -429,6 +431,7 @@ class TransformerDecoderLayerBase(nn.Module):
                 static_kv=True,
                 need_weights=need_attn or (not self.training and self.need_attn),
                 need_head_weights=need_head_weights,
+                encoder_attn_relaxation=encoder_attn_relaxation,                                           
             )
             x = self.dropout_module(x)
             x = self.residual_connection(x, residual)

--- a/fairseq/modules/transformer_layer.py
+++ b/fairseq/modules/transformer_layer.py
@@ -307,7 +307,7 @@ class TransformerDecoderLayerBase(nn.Module):
             vdim=cfg.encoder.embed_dim,
             dropout=cfg.attention_dropout,
             encoder_decoder_attention=True,
-            relaxed_attention_weight=cfg.decoder.relaxed_attention,                     
+            relaxed_attention_weight=cfg.decoder.relaxed_attention_weight,
             q_noise=self.quant_noise,
             qn_block_size=self.quant_noise_block_size,
         )
@@ -330,7 +330,6 @@ class TransformerDecoderLayerBase(nn.Module):
         self_attn_padding_mask: Optional[torch.Tensor] = None,
         need_attn: bool = False,
         need_head_weights: bool = False,
-        encoder_attn_relaxation: float = None,                           
     ):
         """
         Args:
@@ -431,7 +430,6 @@ class TransformerDecoderLayerBase(nn.Module):
                 static_kv=True,
                 need_weights=need_attn or (not self.training and self.need_attn),
                 need_head_weights=need_head_weights,
-                encoder_attn_relaxation=encoder_attn_relaxation,                                           
             )
             x = self.dropout_module(x)
             x = self.residual_connection(x, residual)

--- a/fairseq/modules/transformer_layer.py
+++ b/fairseq/modules/transformer_layer.py
@@ -307,7 +307,6 @@ class TransformerDecoderLayerBase(nn.Module):
             vdim=cfg.encoder.embed_dim,
             dropout=cfg.attention_dropout,
             encoder_decoder_attention=True,
-            relaxed_attention_weight=cfg.decoder.relaxed_attention_weight,
             q_noise=self.quant_noise,
             qn_block_size=self.quant_noise_block_size,
         )


### PR DESCRIPTION
Hey, thanks for the nice work on the espresso toolkit.

Our method 'relaxed attention' was developed using espresso and we want to contribute this here for others to explore. The corresponding paper can be found here ([https://arxiv.org/abs/2107.01275](https://arxiv.org/abs/2107.01275)) and was accepted for presentation at ASRU. 

Without adding any additional parameters or interference complexity we achieved significant WER reduction on WSJ. It seems the works especially good for small datasets. On single-training tests with the most recent version we achieved a eval92 WER of 3.76% compared to 4.16% with the standard recipe. In the paper we also validated with multiple seeds.  

I am looking forward to your comments on that feature.

Best regards from germany,
   Timo Lohrenz