### PR TITLE
conformer

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ We provide state-of-the-art training recipes for the following speech datasets:
 
 ### What's New:
 
+* February 2022: Conformer encoder is implemented. Simply add one line option in the config file to enable it. See examples: [here](https://github.com/freewym/espresso/tree/main/examples/asr_librispeech/config/conformer_librispeech.yaml) and [here](https://github.com/freewym/espresso/tree/main/examples/asr_librispeech/config/conformer_transducer_librispeech.yaml).
 * December 2021: A suite of Transducer model training and decoding code is added. An illustrative LibriSpeech recipe is [here](https://github.com/freewym/espresso/tree/main/examples/asr_librispeech/run_transformer_transducer.sh). The training requires [torchaudio](https://pytorch.org/audio/stable/index.html) >= 0.10.0 installed.
 * April 2021: On-the-fly feature extraction from raw waveforms with [torchaudio](https://pytorch.org/audio/stable/index.html) is supported. A LibriSpeech recipe is released [here](https://github.com/freewym/espresso/tree/main/examples/asr_librispeech/run_torchaudio.sh) with no dependency on Kaldi and using YAML files (via [Hydra](https://hydra.cc/)) for configuring experiments.
 * June 2020: Transformer recipes released.

--- a/espresso/models/speech_lstm_encoder_model.py
+++ b/espresso/models/speech_lstm_encoder_model.py
@@ -129,7 +129,7 @@ class SpeechLSTMEncoderModel(FairseqEncoderModel):
             )
 
         encoder = SpeechChunkLSTMEncoder(
-            conv_layers_before=conv_layers,
+            pre_encoder=conv_layers,
             input_size=rnn_encoder_input_size,
             hidden_size=args.encoder_rnn_hidden_size,
             num_layers=args.encoder_rnn_layers,
@@ -196,7 +196,7 @@ class SpeechChunkLSTMEncoder(SpeechLSTMEncoder):
 
     def __init__(
         self,
-        conv_layers_before=None,
+        pre_encoder=None,
         input_size=83,
         hidden_size=512,
         num_layers=1,
@@ -214,7 +214,7 @@ class SpeechChunkLSTMEncoder(SpeechLSTMEncoder):
         max_source_positions=DEFAULT_MAX_SOURCE_POSITIONS,
     ):
         super().__init__(
-            conv_layers_before=conv_layers_before,
+            pre_encoder=pre_encoder,
             input_size=input_size,
             hidden_size=hidden_size,
             num_layers=num_layers,
@@ -228,14 +228,13 @@ class SpeechChunkLSTMEncoder(SpeechLSTMEncoder):
             max_source_positions=max_source_positions,
         )
         receptive_field_radius = (
-            sum(conv.padding[0] for conv in conv_layers_before.convolutions)
-            if conv_layers_before is not None
+            sum(conv.padding[0] for conv in pre_encoder.convolutions)
+            if pre_encoder is not None
             else 0
         )
         assert chunk_width is None or chunk_width > 0
-        assert (conv_layers_before is None and chunk_left_context >= 0) or (
-            conv_layers_before is not None
-            and chunk_left_context >= receptive_field_radius
+        assert (pre_encoder is None and chunk_left_context >= 0) or (
+            pre_encoder is not None and chunk_left_context >= receptive_field_radius
         )
         self.out_chunk_begin = self.output_lengths(chunk_left_context + 1) - 1
         self.out_chunk_end = (

--- a/espresso/models/transformer/speech_transformer_base.py
+++ b/espresso/models/transformer/speech_transformer_base.py
@@ -146,7 +146,7 @@ class SpeechTransformerModelBase(TransformerModelBase):
 
         encoder = cls.build_encoder(
             cfg,
-            conv_layers_before=conv_layers,
+            pre_encoder=conv_layers,
             input_size=transformer_encoder_input_size,
             transformer_context=encoder_transformer_context,
         )
@@ -167,11 +167,11 @@ class SpeechTransformerModelBase(TransformerModelBase):
 
     @classmethod
     def build_encoder(
-        cls, cfg, conv_layers_before=None, input_size=83, transformer_context=None
+        cls, cfg, pre_encoder=None, input_size=83, transformer_context=None
     ):
         return SpeechTransformerEncoderBase(
             cfg,
-            conv_layers_before=conv_layers_before,
+            pre_encoder=pre_encoder,
             input_size=input_size,
             transformer_context=transformer_context,
         )

--- a/espresso/models/transformer/speech_transformer_config.py
+++ b/espresso/models/transformer/speech_transformer_config.py
@@ -22,6 +22,7 @@ from fairseq.utils import safe_getattr, safe_hasattr
 
 DEFAULT_MAX_SOURCE_POSITIONS = 10240
 DEFAULT_MAX_TARGET_POSITIONS = 1024
+LAYER_TYPE_CHOICES = ChoiceEnum(["transformer", "conformer"])
 
 _NAME_PARSER = r"(decoder|encoder|quant_noise)_(.*)"
 
@@ -56,6 +57,16 @@ class SpeechEncoderConfig(SpeechEncDecBaseConfig):
         metadata={
             "help": "left/right context for time-restricted self-attention; "
             "can be None or a tuple of two non-negative integers/None"
+        },
+    )
+    layer_type: LAYER_TYPE_CHOICES = field(
+        default="transformer", metadata={"help": "layer type in encoder"}
+    )
+    # config specific to Conformer
+    depthwise_conv_kernel_size: int = field(
+        default=31,
+        metadata={
+            "help": "depthwise-conv-kernel-size for convolution in conformer layer"
         },
     )
 

--- a/espresso/models/transformer/speech_transformer_transducer_base.py
+++ b/espresso/models/transformer/speech_transformer_transducer_base.py
@@ -179,7 +179,7 @@ class SpeechTransformerTransducerModelBase(BaseFairseqModel):
 
         encoder = cls.build_encoder(
             cfg,
-            conv_layers_before=conv_layers,
+            pre_encoder=conv_layers,
             input_size=transformer_encoder_input_size,
             transformer_context=encoder_transformer_context,
         )
@@ -207,11 +207,11 @@ class SpeechTransformerTransducerModelBase(BaseFairseqModel):
 
     @classmethod
     def build_encoder(
-        cls, cfg, conv_layers_before=None, input_size=83, transformer_context=None
+        cls, cfg, pre_encoder=None, input_size=83, transformer_context=None
     ):
         return SpeechTransformerEncoderBase(
             cfg,
-            conv_layers_before=conv_layers_before,
+            pre_encoder=pre_encoder,
             input_size=input_size,
             transformer_context=transformer_context,
         )

--- a/espresso/models/transformer/speech_transformer_transducer_config.py
+++ b/espresso/models/transformer/speech_transformer_transducer_config.py
@@ -90,6 +90,9 @@ class SpeechTransformerTransducerConfig(FairseqDataclass):
     layernorm_embedding: bool = field(
         default=True, metadata={"help": "add layernorm to embedding"}
     )
+    no_scale_embedding: bool = field(
+        default=False, metadata={"help": "if True, dont scale embeddings"}
+    )
     checkpoint_activations: bool = field(
         default=False,
         metadata={

--- a/espresso/modules/__init__.py
+++ b/espresso/modules/__init__.py
@@ -3,6 +3,10 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from .conformer_with_relative_positional_embedding_encoder_layer import (
+    ConformerWithRelativePositionalEmbeddingEncoderLayer,
+    ConformerWithRelativePositionalEmbeddingEncoderLayerBase,
+)
 from .relative_positional_embedding import RelativePositionalEmbedding
 from .speech_attention import BahdanauAttention, LuongAttention
 from .speech_convolutions import ConvBNReLU
@@ -15,6 +19,8 @@ from .transformer_with_relative_positional_embedding_layer import (
 
 __all__ = [
     "BahdanauAttention",
+    "ConformerWithRelativePositionalEmbeddingEncoderLayer",
+    "ConformerWithRelativePositionalEmbeddingEncoderLayerBase",
     "ConvBNReLU",
     "LuongAttention",
     "RelativePositionalEmbedding",

--- a/espresso/modules/conformer_with_relative_positional_embedding_encoder_layer.py
+++ b/espresso/modules/conformer_with_relative_positional_embedding_encoder_layer.py
@@ -1,0 +1,165 @@
+# Copyright (c) Yiming Wang
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Optional
+
+import torch
+import torch.nn as nn
+from torch import Tensor
+
+from espresso.modules.relative_positional_embedding import RelativePositionalEmbedding
+from fairseq.models.transformer import TransformerConfig
+from fairseq.modules import LayerNorm, MultiheadAttention
+from fairseq.modules.conformer_layer import ConvolutionModule, FeedForwardModule
+from fairseq.modules.fairseq_dropout import FairseqDropout
+
+
+class ConformerWithRelativePositionalEmbeddingEncoderLayerBase(nn.Module):
+    """Conformer encoder layer block based on https://arxiv.org/abs/2005.08100, with optional relative positional embedding."""
+
+    def __init__(
+        self,
+        cfg,
+        return_fc=False,
+        positional_embedding: Optional[RelativePositionalEmbedding] = None,
+    ):
+        super().__init__()
+        self.cfg = cfg
+        self.return_fc = return_fc
+        self.embed_dim = cfg.encoder.embed_dim
+        self.quant_noise = cfg.quant_noise.pq
+        self.quant_noise_block_size = cfg.quant_noise.pq_block_size
+
+        self.ffn1 = FeedForwardModule(
+            input_feat=self.embed_dim,
+            hidden_units=cfg.encoder.ffn_embed_dim,
+            dropout1=cfg.activation_dropout,
+            dropout2=cfg.dropout,
+            activation_fn="swish",
+        )
+
+        self.self_attn = self.build_self_attention(
+            self.embed_dim, cfg, positional_embedding=positional_embedding
+        )
+        self.self_attn_layer_norm = LayerNorm(self.embed_dim, export=cfg.export)
+        self.dropout_module = FairseqDropout(
+            cfg.dropout, module_name=self.__class__.__name__
+        )
+
+        self.conv_module = ConvolutionModule(
+            embed_dim=self.embed_dim,
+            channels=self.embed_dim,
+            depthwise_kernel_size=cfg.encoder.depthwise_conv_kernel_size,
+            dropout=cfg.dropout,
+            activation_fn="swish",
+        )
+
+        self.ffn2 = FeedForwardModule(
+            input_feat=self.embed_dim,
+            hidden_units=cfg.encoder.ffn_embed_dim,
+            dropout1=cfg.activation_dropout,
+            dropout2=cfg.dropout,
+            activation_fn="swish",
+        )
+
+        self.final_layer_norm = LayerNorm(self.embed_dim, export=cfg.export)
+
+    def build_self_attention(self, embed_dim, cfg, positional_embedding=None):
+        return MultiheadAttention(
+            embed_dim,
+            cfg.encoder.attention_heads,
+            dropout=cfg.attention_dropout,
+            self_attention=True,
+            q_noise=self.quant_noise,
+            qn_block_size=self.quant_noise_block_size,
+            positional_embedding=positional_embedding,
+        )
+
+    def forward(
+        self,
+        x,
+        encoder_padding_mask: Optional[Tensor],
+        attn_mask: Optional[Tensor] = None,
+    ):
+        """
+        Args:
+            x (Tensor): input to the layer of shape `(seq_len, batch, embed_dim)`
+            encoder_padding_mask (ByteTensor): binary ByteTensor of shape
+                `(batch, seq_len)` where padding elements are indicated by ``1``.
+            attn_mask (ByteTensor): binary tensor of shape `(tgt_len, src_len)`,
+                where `tgt_len` is the length of output and `src_len` is the
+                length of input, though here both are equal to `seq_len`.
+                `attn_mask[tgt_i, src_j] = 1` means that when calculating the
+                embedding for `tgt_i`, we exclude (mask out) `src_j`. This is
+                useful for strided self-attention.
+
+        Returns:
+            encoded output of shape `(seq_len, batch, embed_dim)`
+        """
+        # anything in original attn_mask = 1, becomes -1e8
+        # anything in original attn_mask = 0, becomes 0
+        # Note that we cannot use -inf here, because at some edge cases,
+        # the attention weight (before softmax) for some padded element in query
+        # will become -inf, which results in NaN in model parameters
+        if attn_mask is not None:
+            attn_mask = attn_mask.masked_fill(
+                attn_mask.to(torch.bool), -1e8 if x.dtype == torch.float32 else -1e4
+            )
+
+        residual = x
+        x = self.ffn1(x)
+        x = x * 0.5 + residual
+        residual = x
+        x = self.self_attn_layer_norm(x)
+        x, _ = self.self_attn(
+            query=x,
+            key=x,
+            value=x,
+            key_padding_mask=encoder_padding_mask,
+            need_weights=False,
+            attn_mask=attn_mask,
+        )
+        x = self.dropout_module(x)
+        x = x + residual
+
+        residual = x
+        # TBC to BTC
+        x = x.transpose(0, 1)
+        x = self.conv_module(x)
+        # BTC to TBC
+        x = x.transpose(0, 1)
+        x = x + residual
+
+        residual = x
+        x = self.ffn2(x)
+        fc_result = x
+        x = x * 0.5 + residual
+
+        x = self.final_layer_norm(x)
+
+        if self.return_fc and not torch.jit.is_scripting():
+            return x, fc_result
+        return x
+
+
+# backward compatible with the legacy argparse format
+class ConformerWithRelativePositionalEmbeddingEncoderLayer(
+    ConformerWithRelativePositionalEmbeddingEncoderLayerBase
+):
+    def __init__(
+        self, args, positional_embedding: Optional[RelativePositionalEmbedding] = None
+    ):
+        super().__init__(
+            TransformerConfig.from_namespace(args),
+            positional_embedding=positional_embedding,
+        )
+        self.args = args
+
+    def build_self_attention(self, embed_dim, args, positional_embedding=None):
+        return super().build_self_attention(
+            embed_dim,
+            TransformerConfig.from_namespace(args),
+            positional_embedding=positional_embedding,
+        )

--- a/espresso/modules/transformer_with_relative_positional_embedding_layer.py
+++ b/espresso/modules/transformer_with_relative_positional_embedding_layer.py
@@ -5,7 +5,7 @@
 
 from typing import Optional
 
-from espresso.modules import RelativePositionalEmbedding
+from espresso.modules.relative_positional_embedding import RelativePositionalEmbedding
 from fairseq.models.transformer import TransformerConfig
 from fairseq.modules import MultiheadAttention
 from fairseq.modules.transformer_layer import (

--- a/examples/asr_librispeech/config/conformer_librispeech.yaml
+++ b/examples/asr_librispeech/config/conformer_librispeech.yaml
@@ -47,7 +47,7 @@ optimization:
   max_epoch: 100
   clip_norm: 2.0
   update_freq: [1]
-  lr: [0.001]
+  lr: [0.0005]
 
 optimizer:
   _name: adam
@@ -57,7 +57,7 @@ optimizer:
 
 lr_scheduler:
   _name: tri_stage
-  warmup_steps: 2500
+  warmup_steps: 5000
   hold_steps: 90000
   decay_steps: 110000
 
@@ -74,6 +74,8 @@ model:
     normalize_before: true
     learned_pos: true
     relative_positional_embeddings: true
+    layer_type: conformer
+    depthwise_conv_kernel_size: 31
   decoder:
     embed_dim: 512
     ffn_embed_dim: 2048

--- a/examples/asr_librispeech/config/conformer_transducer_librispeech.yaml
+++ b/examples/asr_librispeech/config/conformer_transducer_librispeech.yaml
@@ -5,11 +5,11 @@ common:
   log_format: simple
   log_interval: 1000
   seed: 1
-  empty_cache_freq: 10
+  empty_cache_freq: 5
 
 checkpoint:
   save_dir: checkpoints
-  save_interval_updates: 750
+  save_interval_updates: 1500
   keep_interval_updates: 3
   keep_last_epochs: 5
   best_checkpoint_metric: wer
@@ -20,17 +20,18 @@ task:
   dict: ???
   max_source_positions: 3600
   max_target_positions: 200
+  max_num_expansions_per_step: 2
   global_cmvn_stats_path:
   specaugment_config:
 
 dataset:
   num_workers: 8
-  max_tokens: 26000
-  batch_size: 24
+  max_tokens: 590000
+  batch_size: 16
   data_buffer_size: 100
   train_subset: train
   valid_subset: valid
-  batch_size_valid: 48
+  batch_size_valid: 16
   curriculum: 1
 
 distributed_training:
@@ -38,56 +39,55 @@ distributed_training:
   ddp_backend: legacy_ddp
 
 criterion:
-  _name: label_smoothed_cross_entropy_v2
-  print_training_sample_interval: 500
-  label_smoothing: 0.1
-  smoothing_type: uniform
+  _name: transducer_loss
+  print_training_sample_interval: 1000
 
 optimization:
   max_epoch: 100
   clip_norm: 2.0
-  update_freq: [1]
-  lr: [0.001]
+  update_freq: [2]
+  lr: [5.0]
 
 optimizer:
   _name: adam
-  adam_betas: (0.9,0.999)
+  adam_betas: (0.9,0.98)
   adam_eps: 1e-08
   weight_decay: 0.0
 
 lr_scheduler:
-  _name: tri_stage
-  warmup_steps: 2500
-  hold_steps: 90000
-  decay_steps: 110000
+  _name: noam
+  warmup_steps: 15000
+  model_size: ${model.encoder.embed_dim}
+  final_lr: 1e-6
 
 model:
-  _name: speech_transformer_base
+  _name: speech_transformer_transducer_base
   encoder:
     conv_channels: "[64, 64, 128, 128]"
     conv_kernel_sizes: "[(3, 3), (3, 3), (3, 3), (3, 3)]"
     conv_strides: "[(1, 1), (2, 2), (1, 1), (2, 2)]"
     embed_dim: 512
     ffn_embed_dim: 2048
-    layers: 12
-    attention_heads: 8
-    normalize_before: true
-    learned_pos: true
-    relative_positional_embeddings: true
-  decoder:
-    embed_dim: 512
-    ffn_embed_dim: 2048
-    layers: 6
+    layers: 16
     attention_heads: 8
     normalize_before: true
     learned_pos: false
-    relative_positional_embeddings: false
-    input_dim: 512
-    output_dim: 512
+    relative_positional_embeddings: true
+    layer_type: conformer
+    depthwise_conv_kernel_size: 31
+  decoder:
+    embed_dim: 512
+    hidden_size: 512
+    layers: 2
+    dropout_in: 0.1
+    dropout_out: 0.1
+  joint_dim: 512
+  share_decoder_input_output_embed: false
   attention_dropout: 0.1
   activation_dropout: 0.1
   dropout: 0.1
   activation_fn: relu
+  layernorm_embedding: true
 
 bpe:
   _name: sentencepiece

--- a/examples/asr_librispeech/config/transformer_librispeech_specaug.yaml
+++ b/examples/asr_librispeech/config/transformer_librispeech_specaug.yaml
@@ -25,7 +25,7 @@ task:
 
 dataset:
   num_workers: 8
-  max_tokens: 22000
+  max_tokens: 26000
   batch_size: 24
   data_buffer_size: 100
   train_subset: train
@@ -57,9 +57,9 @@ optimizer:
 
 lr_scheduler:
   _name: tri_stage
-  warmup_steps: 3125
-  hold_steps: 112500
-  decay_steps: 193750
+  warmup_steps: 2500
+  hold_steps: 90000
+  decay_steps: 110000
 
 model:
   _name: speech_transformer_base

--- a/examples/asr_librispeech/run_torchaudio.sh
+++ b/examples/asr_librispeech/run_torchaudio.sh
@@ -228,9 +228,9 @@ if [ ${stage} -le 7 ]; then
   if $use_transformer; then
     update_freq=$(((8+ngpus-1)/ngpus))
     config_name=transformer_librispeech
-    opts="$opts lr_scheduler.warmup_steps=$((25000/ngpus/update_freq))"
-    opts="$opts lr_scheduler.hold_steps=$((900000/ngpus/update_freq))"
-    opts="$opts lr_scheduler.decay_steps=$((1550000/ngpus/update_freq))"
+    opts="$opts lr_scheduler.warmup_steps=$((20000/ngpus/update_freq))"
+    opts="$opts lr_scheduler.hold_steps=$((720000/ngpus/update_freq))"
+    opts="$opts lr_scheduler.decay_steps=$((880000/ngpus/update_freq))"
   else
     update_freq=$(((2+ngpus-1)/ngpus))
     config_name=lstm_librispeech


### PR DESCRIPTION
- Add Conformer encoder for both AED and Transducer models, and example yaml configs (to be tuned).
- rename `conv_layers_before` -> `pre_encoder` in various encoders to be more general.
- update baching/optimization hyper-params in some transformer librispeech recipes.
