### PR TITLE
Bugfix in transformer model creation.

### DIFF
--- a/espresso/models/transformer/speech_transformer_base.py
+++ b/espresso/models/transformer/speech_transformer_base.py
@@ -149,7 +149,8 @@ class SpeechTransformerModelBase(TransformerModelBase):
         super().set_num_updates(num_updates)
 
     @classmethod
-    def build_encoder(cls, cfg, pre_encoder=None, input_size=83):
+    def build_encoder(cls, cfg, pre_encoder=None, input_size=83, transformer_context=None):
+        # transformer_context is unused
         return SpeechTransformerEncoderBase(
             cfg, pre_encoder=pre_encoder, input_size=input_size
         )

--- a/espresso/models/transformer/speech_transformer_legacy.py
+++ b/espresso/models/transformer/speech_transformer_legacy.py
@@ -79,11 +79,11 @@ class SpeechTransformerModel(SpeechTransformerModelBase):
 
     @classmethod
     def build_encoder(
-        cls, args, conv_layers_before=None, input_size=83, transformer_context=None
+        cls, args, pre_encoder=None, input_size=83, transformer_context=None
     ):
         return super().build_encoder(
             SpeechTransformerConfig.from_namespace(args),
-            conv_layers_before=conv_layers_before,
+            pre_encoder=pre_encoder,
             input_size=input_size,
             transformer_context=transformer_context,
         )


### PR DESCRIPTION
Making the signatures of methods compatible:

`SpeechTransformerModelBase.build_encoder(...)`
`SpeechTransformerModel.build_encoder(...)`

(otherwise, the model build crashing)